### PR TITLE
Expand late-game bugs

### DIFF
--- a/src/assets/factories.json
+++ b/src/assets/factories.json
@@ -229,5 +229,233 @@
         ],
         "buyText": "Plant Field",
         "unlockAt": [100,"bees"]
+    },
+    {
+        "name": "Butterfly Garden",
+        "level": 0,
+        "production": [
+            {
+                "type": "butterflies",
+                "increment": 1
+            }
+        ],
+        "costs": [
+            {
+                "type": "nectar",
+                "startingCost": 1000
+            },
+            {
+                "type": "bees",
+                "startingCost": 200
+            }
+        ],
+        "buyText": "Plant Garden",
+        "unlockAt": [500,"nectar"]
+    },
+    {
+        "name": "Spider Nest",
+        "level": 0,
+        "production": [
+            {
+                "type": "spiders",
+                "increment": 0.5
+            }
+        ],
+        "costs": [
+            {
+                "type": "butterflies",
+                "startingCost": 50
+            },
+            {
+                "type": "dirt",
+                "startingCost": 1000
+            }
+        ],
+        "buyText": "Weave Nest",
+        "unlockAt": [200,"butterflies"]
+    },
+    {
+        "name": "Silk Spinners",
+        "level": 0,
+        "production": [
+            {
+                "type": "silk",
+                "increment": 5
+            }
+        ],
+        "costs": [
+            {
+                "type": "spiders",
+                "startingCost": 10
+            },
+            {
+                "type": "leaves",
+                "startingCost": 500
+            },
+            {
+                "type": "water",
+                "startingCost": 500
+            }
+        ],
+        "buyText": "Start Spinners",
+        "unlockAt": [20,"spiders"]
+    },
+    {
+        "name": "Firefly Swarm",
+        "level": 0,
+        "production": [
+            {
+                "type": "fireflies",
+                "increment": 2
+            }
+        ],
+        "costs": [
+            {
+                "type": "silk",
+                "startingCost": 100
+            },
+            {
+                "type": "nectar",
+                "startingCost": 2000
+            }
+        ],
+        "buyText": "Attract Swarm",
+        "unlockAt": [500,"silk"]
+    },
+    {
+        "name": "Glowworm Caves",
+        "level": 0,
+        "production": [
+            {
+                "type": "glowJuice",
+                "increment": 5
+            }
+        ],
+        "costs": [
+            {
+                "type": "fireflies",
+                "startingCost": 50
+            },
+            {
+                "type": "mud",
+                "startingCost": 1000
+            },
+            {
+                "type": "water",
+                "startingCost": 1000
+            }
+        ],
+        "buyText": "Dig Caves",
+        "unlockAt": [100,"fireflies"]
+    },
+    {
+        "name": "Mantis Dojo",
+        "level": 0,
+        "production": [
+            {
+                "type": "mantises",
+                "increment": 1
+            }
+        ],
+        "costs": [
+            {
+                "type": "glowJuice",
+                "startingCost": 200
+            },
+            {
+                "type": "eggs",
+                "startingCost": 1000
+            }
+        ],
+        "buyText": "Train Mantises",
+        "unlockAt": [200,"glowJuice"]
+    },
+    {
+        "name": "Chitin Foundry",
+        "level": 0,
+        "production": [
+            {
+                "type": "chitin",
+                "increment": 5
+            }
+        ],
+        "costs": [
+            {
+                "type": "mantises",
+                "startingCost": 10
+            },
+            {
+                "type": "mud",
+                "startingCost": 2000
+            }
+        ],
+        "buyText": "Forge Chitin",
+        "unlockAt": [10,"mantises"]
+    },
+    {
+        "name": "Dragonfly Pond",
+        "level": 0,
+        "production": [
+            {
+                "type": "dragonflies",
+                "increment": 2
+            }
+        ],
+        "costs": [
+            {
+                "type": "water",
+                "startingCost": 5000
+            },
+            {
+                "type": "leaves",
+                "startingCost": 3000
+            }
+        ],
+        "buyText": "Build Pond",
+        "unlockAt": [1000,"chitin"]
+    },
+    {
+        "name": "Stinkbug Lab",
+        "level": 0,
+        "production": [
+            {
+                "type": "pheromones",
+                "increment": 1
+            }
+        ],
+        "costs": [
+            {
+                "type": "dragonflies",
+                "startingCost": 20
+            },
+            {
+                "type": "chitin",
+                "startingCost": 1000
+            }
+        ],
+        "buyText": "Research Lab",
+        "unlockAt": [30,"dragonflies"]
+    },
+    {
+        "name": "Wasp Hive",
+        "level": 0,
+        "production": [
+            {
+                "type": "wasps",
+                "increment": 1
+            }
+        ],
+        "costs": [
+            {
+                "type": "pheromones",
+                "startingCost": 200
+            },
+            {
+                "type": "bees",
+                "startingCost": 1000
+            }
+        ],
+        "buyText": "Raise Wasps",
+        "unlockAt": [100,"pheromones"]
     }
 ]

--- a/src/assets/resources.json
+++ b/src/assets/resources.json
@@ -52,5 +52,55 @@
         "name": "Nectar",
         "color": "#ff38a2",
         "workText": "Attracting"
+    },
+    "butterflies":{
+        "name": "Butterflies",
+        "color": "#f8a2ff",
+        "workText": "Fluttering"
+    },
+    "spiders":{
+        "name": "Spiders",
+        "color": "#2f2f2f",
+        "workText": "Spinning"
+    },
+    "silk":{
+        "name": "Silk",
+        "color": "#f0e6d6",
+        "workText": "Weaving"
+    },
+    "fireflies":{
+        "name": "Fireflies",
+        "color": "#e1ff00",
+        "workText": "Glowing"
+    },
+    "glowJuice":{
+        "name": "Glow Juice",
+        "color": "#00ffc8",
+        "workText": "Juicing"
+    },
+    "mantises":{
+        "name": "Mantises",
+        "color": "#5fb236",
+        "workText": "Training"
+    },
+    "chitin":{
+        "name": "Chitin",
+        "color": "#705a36",
+        "workText": "Hardening"
+    },
+    "dragonflies":{
+        "name": "Dragonflies",
+        "color": "#69c4ff",
+        "workText": "Soaring"
+    },
+    "pheromones":{
+        "name": "Pheromones",
+        "color": "#ff00e1",
+        "workText": "Synthesizing"
+    },
+    "wasps":{
+        "name": "Wasps",
+        "color": "#d99b2b",
+        "workText": "Stinging"
     }
 }


### PR DESCRIPTION
## Summary
- add many late-game resources for advanced bugs
- add 10 new collector types with sequential unlocks

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_687838471b6c832ab08cfa870606adb3